### PR TITLE
[feat/1 oauth2]: OAuth2 유저 정보 받아오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### client secret file
+src/main/resources/application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	//runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/wondrous/oauth_jwt/conig/SecurityConfig.java
+++ b/src/main/java/com/wondrous/oauth_jwt/conig/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.wondrous.oauth_jwt.conig;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .oauth2Login(Customizer.withDefaults())
+
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/wondrous/oauth_jwt/conig/SecurityConfig.java
+++ b/src/main/java/com/wondrous/oauth_jwt/conig/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.wondrous.oauth_jwt.conig;
 
 
+import com.wondrous.oauth_jwt.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,9 +13,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
+@RequiredArgsConstructor
 
 @Configuration
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -21,7 +26,10 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .oauth2Login(Customizer.withDefaults())
+                //유저 엔드 포인트를 customOAuth2UserService로 설정
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig ->
+                                userInfoEndpointConfig.userService(customOAuth2UserService))))
 
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()

--- a/src/main/java/com/wondrous/oauth_jwt/controller/MainController.java
+++ b/src/main/java/com/wondrous/oauth_jwt/controller/MainController.java
@@ -1,0 +1,14 @@
+package com.wondrous.oauth_jwt.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String mainPage() {
+        return "/main";
+    }
+}

--- a/src/main/java/com/wondrous/oauth_jwt/controller/MyController.java
+++ b/src/main/java/com/wondrous/oauth_jwt/controller/MyController.java
@@ -1,0 +1,11 @@
+package com.wondrous.oauth_jwt.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class MyController {
+
+    @GetMapping("/my")
+    public String myPage() {
+        return "my";
+    }
+}

--- a/src/main/java/com/wondrous/oauth_jwt/controller/MyController.java
+++ b/src/main/java/com/wondrous/oauth_jwt/controller/MyController.java
@@ -1,7 +1,10 @@
 package com.wondrous.oauth_jwt.controller;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+
+@Controller
 public class MyController {
 
     @GetMapping("/my")

--- a/src/main/java/com/wondrous/oauth_jwt/dto/CustomOAuth2User.java
+++ b/src/main/java/com/wondrous/oauth_jwt/dto/CustomOAuth2User.java
@@ -1,0 +1,48 @@
+package com.wondrous.oauth_jwt.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final OAuth2Response oAuth2Response;
+    private final String role;
+
+
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return role;
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2Response.getName();
+    }
+
+    public String getUserName() {
+        return oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+    }
+
+}

--- a/src/main/java/com/wondrous/oauth_jwt/dto/GoogleResponse.java
+++ b/src/main/java/com/wondrous/oauth_jwt/dto/GoogleResponse.java
@@ -1,0 +1,32 @@
+package com.wondrous.oauth_jwt.dto;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/wondrous/oauth_jwt/dto/KaKaoResponse.java
+++ b/src/main/java/com/wondrous/oauth_jwt/dto/KaKaoResponse.java
@@ -1,0 +1,34 @@
+package com.wondrous.oauth_jwt.dto;
+
+
+import java.util.Map;
+
+public class KaKaoResponse implements OAuth2Response {
+    private final Map<String, Object> attribute;
+
+    public KaKaoResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+        System.out.println("Kakao attribute: " + attribute);
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attribute.get("properties");
+        return properties.get("nickname").toString();
+    }
+}

--- a/src/main/java/com/wondrous/oauth_jwt/dto/NaverResponse.java
+++ b/src/main/java/com/wondrous/oauth_jwt/dto/NaverResponse.java
@@ -1,0 +1,35 @@
+package com.wondrous.oauth_jwt.dto;
+
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+
+}

--- a/src/main/java/com/wondrous/oauth_jwt/dto/OAuth2Response.java
+++ b/src/main/java/com/wondrous/oauth_jwt/dto/OAuth2Response.java
@@ -1,0 +1,10 @@
+package com.wondrous.oauth_jwt.dto;
+
+
+public interface OAuth2Response {
+
+    String getProvider();
+    String getProviderId();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package com.wondrous.oauth_jwt.service;
+
+
+import com.wondrous.oauth_jwt.dto.GoogleResponse;
+import com.wondrous.oauth_jwt.dto.KaKaoResponse;
+import com.wondrous.oauth_jwt.dto.NaverResponse;
+import com.wondrous.oauth_jwt.dto.OAuth2Response;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println("oAuth2User = " + oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2Response oAuth2Response = null;
+
+        if(registrationId == "naver") {
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        }
+        else if (registrationId == "kakao") {
+            oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
+        }
+        else if (registrationId == "google") {
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else {
+            System.out.println("유효하지 않은 로그인 방식입니다.");
+            throw new OAuth2AuthenticationException("유효하지 않은 로그인 방식");
+        }
+        // 이후 작성 예정
+
+        return oAuth2User;
+    }
+}
+

--- a/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
@@ -1,10 +1,7 @@
 package com.wondrous.oauth_jwt.service;
 
 
-import com.wondrous.oauth_jwt.dto.GoogleResponse;
-import com.wondrous.oauth_jwt.dto.KaKaoResponse;
-import com.wondrous.oauth_jwt.dto.NaverResponse;
-import com.wondrous.oauth_jwt.dto.OAuth2Response;
+import com.wondrous.oauth_jwt.dto.*;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -23,13 +20,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2Response oAuth2Response = null;
 
-        if(registrationId == "naver") {
+        System.out.println("registrationID: " + registrationId);
+
+        if(registrationId.equals("naver")) {
             oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
         }
-        else if (registrationId == "kakao") {
+        else if (registrationId.equals("kakao")) {
             oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
         }
-        else if (registrationId == "google") {
+        else if (registrationId.equals("google")) {
             oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
         }
         else {
@@ -38,7 +37,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
         // 이후 작성 예정
 
-        return oAuth2User;
+        String role = "ROLE_USER";
+
+        /**
+         * 기본 반환 형태: return oAuth2User;
+         * OAuth2User형태로 반환해야 하지만 OAuth2User을 상속받은 CustomOAuth2User으로 반환
+         */
+        return new CustomOAuth2User(oAuth2Response, role);
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=oauth-jwt

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    include: oauth

--- a/src/main/resources/templates/main.mustache
+++ b/src/main/resources/templates/main.mustache
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Main Page</title>
+</head>
+<body>
+    main page
+</body>
+</html>

--- a/src/main/resources/templates/my.mustache
+++ b/src/main/resources/templates/my.mustache
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>MyPage</title>
+</head>
+<body>
+    my page
+</body>
+</html>


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-oauth2-jwt-honds-on-Spring-boot-3/issues/1
  
  


# 🔑 Key Changes
- 테스트를 위한 기본 페이지 컨트롤러들 구현
- 테스트를 위한 기본 뷰 페이지들 구현
- SecurityConfig 설정 등록 후 Bean에 등록
- yml설정 파일 구현
- DefaultOAuth2UserService 구현체로 CustomOAuth2Service 구현 후 유저 엔드 포인트로 등록
- google, naver, kakao 각각의 응답을 받기 위해 OAuth2Response 구현체로 Response Dto구현 후 CustomOAuth2UserService에 적용



# 📢 After To-do
- [ ] 유저 정보 DB에 저장하기
- [ ] 로그인 페이지 관련 커스텀 설정
- [ ] 보안 관련 설정 등록