### PR TITLE
[feat/#1-oauth2]: 유저 정보 DB 저장하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ repositories {
 }
 
 dependencies {
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/wondrous/oauth_jwt/entity/OAuth2Member.java
+++ b/src/main/java/com/wondrous/oauth_jwt/entity/OAuth2Member.java
@@ -1,0 +1,31 @@
+package com.wondrous.oauth_jwt.entity;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+
+@Entity
+public class OAuth2Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private String memberName;
+
+    private String email;
+
+    private String role;
+}

--- a/src/main/java/com/wondrous/oauth_jwt/repository/MemberRepository.java
+++ b/src/main/java/com/wondrous/oauth_jwt/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.wondrous.oauth_jwt.repository;
+
+import com.wondrous.oauth_jwt.entity.OAuth2Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<OAuth2Member, Long> {
+    OAuth2Member findByMemberName(String memberName);
+
+
+}

--- a/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/wondrous/oauth_jwt/service/CustomOAuth2UserService.java
@@ -2,14 +2,21 @@ package com.wondrous.oauth_jwt.service;
 
 
 import com.wondrous.oauth_jwt.dto.*;
+import com.wondrous.oauth_jwt.entity.OAuth2Member;
+import com.wondrous.oauth_jwt.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
+
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -35,9 +42,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             System.out.println("유효하지 않은 로그인 방식입니다.");
             throw new OAuth2AuthenticationException("유효하지 않은 로그인 방식");
         }
-        // 이후 작성 예정
+        // 유저 존재 여부 확인 후 가입 처리 로직
 
-        String role = "ROLE_USER";
+        String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+        OAuth2Member existData = memberRepository.findByMemberName(username);
+        String role = null;
+
+        if (existData == null) {
+            OAuth2Member newOauth2Member = new OAuth2Member();
+            newOauth2Member.setMemberName(username);
+            newOauth2Member.setEmail(oAuth2Response.getEmail());
+            newOauth2Member.setRole("ROLE_USER");
+
+            memberRepository.save(newOauth2Member);
+        }
+        else {
+
+            role = existData.getRole();
+            existData.setEmail(oAuth2Response.getEmail());
+            memberRepository.save(existData);
+        }
 
         /**
          * 기본 반환 형태: return oAuth2User;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
   application:
     name: OAuth2 JWT
 
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -13,7 +14,7 @@ spring:
 
     properties:
       hibernate:
-        ddl-auto: update
+        #dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
@@ -29,10 +30,10 @@ server:
       charset: UTF-8
       force-response: 'true'
 
-
 logging:
   level:
     root: info
     org.hibernate.sql: debug
     org.hibernate.type.descriptor.sql: debug
     org.springframework.security: trace
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,38 @@
 spring:
   profiles:
     include: oauth
+
+  application:
+    name: OAuth2 JWT
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+    properties:
+      hibernate:
+        ddl-auto: update
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/oauth2?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+    username: root
+    password: "0000"
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force-response: 'true'
+
+
+logging:
+  level:
+    root: info
+    org.hibernate.sql: debug
+    org.hibernate.type.descriptor.sql: debug
+    org.springframework.security: trace


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-oauth2-jwt-honds-on-Spring-boot-3/issues/1
  
  


# 🔑 Key Changes
- application.yml 관련 설정 추가
- 로그인 시 유저 정보 조회 구현



# 📢 After To-do
- [ ] spring jpa No LoadTimeWeaver setup관련 트러블 슈팅
- [ ] 로그인 페이지 관련 커스텀 설정
- [ ] 보안 관련 설정 등록