### PR TITLE
[fix/#1-oauth2]: spring jpa No LoadTimeWeaver setup 트러블 슈팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
+	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-oauth2-jwt-honds-on-Spring-boot-3/issues/1

# 문제 원인
스프링 최신 버전인 3.4.0은 spring data jpa에서 timezone 등록이 안되는 문제 발생
  
  


# 🔑 Key Changes
- 스프링 버전 변경 3.4.0 -> 3.3.5로 변경



# 📢 참조 링크
- https://docs.spring.io/spring-framework/reference/core/beans/context-load-time-weaver.html